### PR TITLE
correct the formatting of the compose file and change a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run -d \
 
 | Docker Environment Var | Description|
 | --- | --- |
-| `ServerIP: <Host's IP>`<br/> | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
+| `FTLCONF_LOCAL_IPV4: <Host's IP>`<br/> | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `TZ: <Timezone>`<br/> | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `WEBPASSWORD: <Admin password>`<br/> | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
 | `REV_SERVER: <"true"\|"false">`<br/> | Enable DNS conditional forwarding for device name resolution
@@ -46,7 +46,7 @@ docker run -d \
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 
 ```
-ServerIP=192.168.1.10
+FTLCONF_LOCAL_IPV4=192.168.1.10
 TZ=America/Los_Angeles
 WEBPASSWORD=QWERTY123456asdfASDF
 REV_SERVER=true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
       - REV_SERVER_CIDR=${REV_SERVER_CIDR}
       - PIHOLE_DNS_=127.0.0.1#5335 # Hardcoded to our Unbound server
-      - DNSSEC="true" # Enable DNSSEC
+      - DNSSEC=true # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,15 +18,15 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - ServerIP: ${ServerIP}
-      - TZ: ${TZ}
-      - WEBPASSWORD: ${WEBPASSWORD}
-      - REV_SERVER: ${REV_SERVER}
-      - REV_SERVER_TARGET: ${REV_SERVER_TARGET}
-      - REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}
-      - REV_SERVER_CIDR: ${REV_SERVER_CIDR}
-      - PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
-      - DNSSEC: "true" # Enable DNSSEC
+      - ServerIP=${ServerIP}
+      - TZ=${TZ}
+      - WEBPASSWORD=${WEBPASSWORD}
+      - REV_SERVER=${REV_SERVER}
+      - REV_SERVER_TARGET=${REV_SERVER_TARGET}
+      - REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
+      - REV_SERVER_CIDR=${REV_SERVER_CIDR}
+      - PIHOLE_DNS_=127.0.0.1#5335 # Hardcoded to our Unbound server
+      - DNSSEC="true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - ServerIP=${ServerIP}
+      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
       - TZ=${TZ}
       - WEBPASSWORD=${WEBPASSWORD}
       - REV_SERVER=${REV_SERVER}


### PR DESCRIPTION
This corrects formatting in the defined env's in the docker-compose.yml and changes the variable (env) ServerIP to the currently appropriate variable for the pihole v5