### PR TITLE
conversion to pihole v6

### DIFF
--- a/ .gitlab-ci.yml
+++ b/ .gitlab-ci.yml
@@ -7,8 +7,8 @@ variables:
   DOCKER_HUB: "true"
   # Override CI_PROJECT_PATH for using correct DOCKERHUB path
   CI_PROJECT_PATH: "fabianbees/pihole-unbound"
-  BASE_VERSION: "2024.02.0"
-  VERSION: "2024.02.0"
+  BASE_VERSION: "development-v6"
+  VERSION: "development-v6"
 
 # Build Stages
 stages:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ stages:
     - export BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')
     - |
       if [[ -z "$CI_COMMIT_TAG" ]]; then
-        export CI_APPLICATION_TAG="latest"
+        export CI_APPLICATION_TAG="development-v6"
       else
         export CI_APPLICATION_TAG=${CI_APPLICATION_TAG:-$CI_COMMIT_TAG}
       fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # set version label
 ARG BASE_VERSION
 
-FROM pihole/pihole:"${BASE_VERSION}"
-RUN apt update && apt install -y unbound
+#FROM pihole/pihole:"${BASE_VERSION}"
+FROM pihole/pihole:development-v6
+RUN apk add --no-cache \
+    unbound 
 
-COPY lighttpd-external.conf /etc/lighttpd/external.conf 
+#COPY lighttpd-external.conf /etc/lighttpd/external.conf 
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 RUN mkdir -p /etc/services.d/unbound
 COPY unbound-run /etc/services.d/unbound/run
 
-ENTRYPOINT ./s6-init
+ENTRYPOINT ["/sbin/tini", "--", "start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 # set version label
 ARG BASE_VERSION
 
-#FROM pihole/pihole:"${BASE_VERSION}"
-FROM pihole/pihole:development-v6
+FROM pihole/pihole:"${BASE_VERSION}"
 RUN apk add --no-cache \
     unbound 
 
-#COPY lighttpd-external.conf /etc/lighttpd/external.conf 
 COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 RUN mkdir -p /etc/services.d/unbound

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ COPY unbound-pihole.conf /etc/unbound/unbound.conf.d/pi-hole.conf
 COPY 99-edns.conf /etc/dnsmasq.d/99-edns.conf
 RUN mkdir -p /etc/services.d/unbound
 COPY unbound-run /etc/services.d/unbound/run
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-ENTRYPOINT ["/sbin/tini", "--", "start.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker run -d \
 
 | Docker Environment Var | Description|
 | --- | --- |
-| `ServerIP: <Host's IP>`<br/> | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
+| `FTLCONF_LOCAL_IPV4: <Host's IP>`<br/> | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `TZ: <Timezone>`<br/> | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `FTLCONF_webserver_api_password: <Admin password>`<br/> | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
 | `REV_SERVER: <"true"\|"false">`<br/> | Enable DNS conditional forwarding for device name resolution
@@ -45,7 +45,7 @@ docker run -d \
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 
 ```
-ServerIP=192.168.1.10
+FTLCONF_LOCAL_IPV4=192.168.1.10
 TZ=America/Los_Angeles
 FTLCONF_webserver_api_password=QWERTY123456asdfASDF
 REV_SERVER=true

--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ docker run -d \
   -e TZ="Europe/Berlin" \
   -e 'TCP_PORT_53'='53' -e 'UDP_PORT_53'='53' -e 'UDP_PORT_67'='67' -e 'TCP_PORT_80'='80' -e 'TCP_PORT_443'='443' \
   -e 'TZ'='Europe/Berlin' \
-  -e 'WEBPASSWORD'='******' \
+  -e 'FTLCONF_webserver_api_password'='******' \
   -v "$PWD/pihole/pihole/":'/etc/pihole/':'rw' \
   -v "$PWD/pihole/dnsmasq.d/":'/etc/dnsmasq.d/':'rw' \
-  -v "$PWD/pihole/external.conf":'/etc/lighttpd/external.conf':'rw' \
   --cap-add=NET_ADMIN \
   --hostname=pihole \
   'fabianbees/pihole-unbound:latest'
@@ -36,7 +35,7 @@ docker run -d \
 | --- | --- |
 | `ServerIP: <Host's IP>`<br/> | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `TZ: <Timezone>`<br/> | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
-| `WEBPASSWORD: <Admin password>`<br/> | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
+| `FTLCONF_webserver_api_password: <Admin password>`<br/> | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
 | `REV_SERVER: <"true"\|"false">`<br/> | Enable DNS conditional forwarding for device name resolution
 | `REV_SERVER_DOMAIN: <Network Domain>`<br/> | If conditional forwarding is enabled, set the domain of the local network router
 | `REV_SERVER_TARGET: <Router's IP>`<br/> | If conditional forwarding is enabled, set the IP of the local network router
@@ -48,7 +47,7 @@ Example `.env` file in the same directory as your `docker-compose.yaml` file:
 ```
 ServerIP=192.168.1.10
 TZ=America/Los_Angeles
-WEBPASSWORD=QWERTY123456asdfASDF
+FTLCONF_webserver_api_password=QWERTY123456asdfASDF
 REV_SERVER=true
 REV_SERVER_DOMAIN=local
 REV_SERVER_TARGET=192.168.1.1

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run -d \
   -v "$PWD/pihole/dnsmasq.d/":'/etc/dnsmasq.d/':'rw' \
   --cap-add=NET_ADMIN \
   --hostname=pihole \
-  'fabianbees/pihole-unbound:latest'
+  'fabianbees/pihole-unbound:development-v6'
 ```
 
 
@@ -33,25 +33,17 @@ docker run -d \
 
 | Docker Environment Var | Description|
 | --- | --- |
-| `FTLCONF_LOCAL_IPV4: <Host's IP>`<br/> | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `TZ: <Timezone>`<br/> | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `FTLCONF_webserver_api_password: <Admin password>`<br/> | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `REV_SERVER: <"true"\|"false">`<br/> | Enable DNS conditional forwarding for device name resolution
-| `REV_SERVER_DOMAIN: <Network Domain>`<br/> | If conditional forwarding is enabled, set the domain of the local network router
-| `REV_SERVER_TARGET: <Router's IP>`<br/> | If conditional forwarding is enabled, set the IP of the local network router
-| `REV_SERVER_CIDR: <Reverse DNS>`<br/>| If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`)
+| `FTLCONF_dns_revServers: <enabled>,<ip-address>[/<prefix-len>],<server>[#<port>],<domain>`<br/> | Enable Reverse server (former also called "conditional forwarding") feature
 | `USE_IPV6: <"true"\|"false">`<br/>| Set to `true` if ipv6 is needed for unbound (not required in most use-cases)
 
 Example `.env` file in the same directory as your `docker-compose.yaml` file:
 
 ```
-FTLCONF_LOCAL_IPV4=192.168.1.10
 TZ=America/Los_Angeles
 FTLCONF_webserver_api_password=QWERTY123456asdfASDF
-REV_SERVER=true
-REV_SERVER_DOMAIN=local
-REV_SERVER_TARGET=192.168.1.1
-REV_SERVER_CIDR=192.168.0.0/16
+FTLCONF_dns_revServers=true,192.168.0.0/16,192.168.1.1,local
 HOSTNAME=pihole
 DOMAIN_NAME=pihole.local
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,16 +18,16 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - ServerIP: ${ServerIP}
-      - TZ: ${TZ}
-      - FTLCONF_webserver_api_password: ${FTLCONF_webserver_api_password}
-      - REV_SERVER: ${REV_SERVER}
-      - REV_SERVER_TARGET: ${REV_SERVER_TARGET}
-      - REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}
-      - REV_SERVER_CIDR: ${REV_SERVER_CIDR}
+      - ServerIP=${ServerIP}
+      - TZ=${TZ}
+      - FTLCONF_webserver_api_password=${FTLCONF_webserver_api_password}
+      - REV_SERVER=${REV_SERVER}
+      - REV_SERVER_TARGET=${REV_SERVER_TARGET}
+      - REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
+      - REV_SERVER_CIDR=${REV_SERVER_CIDR}
  #     - PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
-      - FTLCONF_dns_upstreams: 127.0.0.1#5335
-      - DNSSEC: "true" # Enable DNSSEC
+      - FTLCONF_dns_upstreams=127.0.0.1#5335
+      - DNSSEC="true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,8 +21,8 @@ services:
       - TZ=${TZ}
       - FTLCONF_webserver_api_password=${FTLCONF_webserver_api_password}
       - FTLCONF_dns_revServers=${FTLCONF_dns_revServers}
-      - FTLCONF_dns_upstreams=127.0.0.1#5335
-      - FTLCONF_dns_dnssec="true" # Enable DNSSEC
+      - FTLCONF_dns_upstreams=127.0.0.1#5335 # Hardcoded to our Unbound server
+      - FTLCONF_dns_dnssec=true # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,6 @@ services:
       - TZ=${TZ}
       - FTLCONF_webserver_api_password=${FTLCONF_webserver_api_password}
       - FTLCONF_dns_revServers=${FTLCONF_dns_revServers}
- #     - PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
       - FTLCONF_dns_upstreams=127.0.0.1#5335
       - FTLCONF_dns_dnssec="true" # Enable DNSSEC
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ volumes:
 services:
   pihole:
     container_name: pihole
-    image: fabianbees/pihole-unbound:latest
+    image: fabianbees/pihole-unbound:development-v6
     hostname: ${HOSTNAME}
     domainname: ${DOMAIN_NAME}
     ports:
@@ -20,12 +20,13 @@ services:
     environment:
       - ServerIP: ${ServerIP}
       - TZ: ${TZ}
-      - WEBPASSWORD: ${WEBPASSWORD}
+      - FTLCONF_webserver_api_password: ${WEBPASSWORD}
       - REV_SERVER: ${REV_SERVER}
       - REV_SERVER_TARGET: ${REV_SERVER_TARGET}
       - REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}
       - REV_SERVER_CIDR: ${REV_SERVER_CIDR}
-      - PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
+ #     - PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
+      - FTLCONF_dns_upstreams: 127.0.0.1#5335
       - DNSSEC: "true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - ServerIP=${ServerIP}
+      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
       - TZ=${TZ}
       - FTLCONF_webserver_api_password=${FTLCONF_webserver_api_password}
       - REV_SERVER=${REV_SERVER}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,16 +18,12 @@ services:
       # - 5335:5335/tcp # Uncomment to enable unbound access on local server
       # - 22/tcp # Uncomment to enable SSH
     environment:
-      - FTLCONF_LOCAL_IPV4=${FTLCONF_LOCAL_IPV4}
       - TZ=${TZ}
       - FTLCONF_webserver_api_password=${FTLCONF_webserver_api_password}
-      - REV_SERVER=${REV_SERVER}
-      - REV_SERVER_TARGET=${REV_SERVER_TARGET}
-      - REV_SERVER_DOMAIN=${REV_SERVER_DOMAIN}
-      - REV_SERVER_CIDR=${REV_SERVER_CIDR}
+      - FTLCONF_dns_revServers=${FTLCONF_dns_revServers}
  #     - PIHOLE_DNS_: 127.0.0.1#5335 # Hardcoded to our Unbound server
       - FTLCONF_dns_upstreams=127.0.0.1#5335
-      - DNSSEC="true" # Enable DNSSEC
+      - FTLCONF_dns_dnssec="true" # Enable DNSSEC
     volumes:
       - etc_pihole-unbound:/etc/pihole:rw
       - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       - ServerIP: ${ServerIP}
       - TZ: ${TZ}
-      - FTLCONF_webserver_api_password: ${WEBPASSWORD}
+      - FTLCONF_webserver_api_password: ${FTLCONF_webserver_api_password}
       - REV_SERVER: ${REV_SERVER}
       - REV_SERVER_TARGET: ${REV_SERVER_TARGET}
       - REV_SERVER_DOMAIN: ${REV_SERVER_DOMAIN}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+echo starting pihole
+/usr/bin/start.sh &
+
+
+SERVICESD=$(ls /etc/services.d/)
+for SERVICED in ${SERVICESD}; do
+	echo starting $SERVICED
+	/etc/services.d/$SERVICED/run &
+done
+
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-echo starting pihole
-/usr/bin/start.sh &
-
 
 SERVICESD=$(ls /etc/services.d/)
 for SERVICED in ${SERVICESD}; do
@@ -10,5 +7,7 @@ for SERVICED in ${SERVICESD}; do
 	/etc/services.d/$SERVICED/run &
 done
 
+echo starting pihole
+/usr/bin/start.sh
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 
 SERVICESD=$(ls /etc/services.d/)
 for SERVICED in ${SERVICESD}; do
-	echo starting $SERVICED
+	echo starting $SERVICED service
 	/etc/services.d/$SERVICED/run &
 done
 

--- a/lighttpd-external.conf
+++ b/lighttpd-external.conf
@@ -1,6 +1,0 @@
-$HTTP["url"] =~ "^/admin/" {
-      # Allow using Pi-Hole admin in iframes (eg, for Home Assistant)
-      setenv.set-response-header += (
-         "X-Frame-Options" => "Allow"
-      )
-}

--- a/unbound-run
+++ b/unbound-run
@@ -15,7 +15,6 @@ DAEMON="/usr/sbin/unbound"
 PIDFILE="/run/unbound.pid"
 
 ANCHOR="/usr/sbin/unbound-anchor"
-#HELPER="/usr/lib/unbound/package-helper"
 
 test -x $DAEMON || exit 0
 
@@ -26,8 +25,6 @@ if [ -f /etc/default/unbound ]; then
     . /etc/default/unbound
 fi
 
-#$HELPER chroot_setup
-#$HELPER root_trust_anchor_update 2>&1 | logger -p daemon.info -t unbound-anchor
 $ANCHOR -v
 
 $DAEMON -d $DAEMON_OPTS

--- a/unbound-run
+++ b/unbound-run
@@ -14,7 +14,8 @@ DESC="DNS server"
 DAEMON="/usr/sbin/unbound"
 PIDFILE="/run/unbound.pid"
 
-HELPER="/usr/lib/unbound/package-helper"
+ANCHOR=/usr/sbin/unbound-anchor"
+#HELPER="/usr/lib/unbound/package-helper"
 
 test -x $DAEMON || exit 0
 
@@ -25,7 +26,8 @@ if [ -f /etc/default/unbound ]; then
     . /etc/default/unbound
 fi
 
-$HELPER chroot_setup
-$HELPER root_trust_anchor_update 2>&1 | logger -p daemon.info -t unbound-anchor
+#$HELPER chroot_setup
+#$HELPER root_trust_anchor_update 2>&1 | logger -p daemon.info -t unbound-anchor
+$ANCHOR -v
 
 $DAEMON -d $DAEMON_OPTS

--- a/unbound-run
+++ b/unbound-run
@@ -1,4 +1,4 @@
-#!/command/with-contenv bash
+#!/bin/bash
 
 # set num-threads for unbound matching the running machine
 sed -i "s/num-threads: 1/num-threads: $(nproc --all)/" /etc/unbound/unbound.conf.d/pi-hole.conf
@@ -7,7 +7,7 @@ if [ "$USE_IPV6" == "true" ]; then
 fi
 
 
-s6-echo "Starting unbound"
+echo "Starting unbound"
 
 NAME="unbound"
 DESC="DNS server"

--- a/unbound-run
+++ b/unbound-run
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+UNBOUND_CONF="/etc/unbound/unbound.conf.d/pi-hole.conf"
+
 # set num-threads for unbound matching the running machine
-sed -i "s/num-threads: 1/num-threads: $(nproc --all)/" /etc/unbound/unbound.conf.d/pi-hole.conf
+sed -i "s/num-threads: 1/num-threads: $(nproc --all)/" $UNBOUND_CONF
 if [ "$USE_IPV6" == "true" ]; then
-    sed -i "s/do-ip6: no/do-ip6: yes/" /etc/unbound/unbound.conf.d/pi-hole.conf
+    sed -i "s/do-ip6: no/do-ip6: yes/" $UNBOUND_CONF
 fi
 
 
@@ -21,10 +23,6 @@ test -x $DAEMON || exit 0
 # Override this variable by editing or creating /etc/default/unbound.
 DAEMON_OPTS=""
 
-if [ -f /etc/default/unbound ]; then
-    . /etc/default/unbound
-fi
-
 $ANCHOR -v
 
-$DAEMON -d $DAEMON_OPTS
+$DAEMON -d $DAEMON_OPTS -c $UNBOUND_CONF

--- a/unbound-run
+++ b/unbound-run
@@ -14,7 +14,7 @@ DESC="DNS server"
 DAEMON="/usr/sbin/unbound"
 PIDFILE="/run/unbound.pid"
 
-ANCHOR=/usr/sbin/unbound-anchor"
+ANCHOR="/usr/sbin/unbound-anchor"
 #HELPER="/usr/lib/unbound/package-helper"
 
 test -x $DAEMON || exit 0


### PR DESCRIPTION
This is a big change with this pull request because things had to be changed in some places so that this docker container can also run with pihole v6 (and remains so).

The variables (env's) and the docker file as well as some files from unbound were adjusted.

**Please do this because the tags focus on development-v6 from pihole, this is on a branch of the same name and not on master if pihole has not yet released v6 as stable.**